### PR TITLE
Add workflow to publish docs on Github Pages

### DIFF
--- a/.github/workflows/make-sphinx-docs.yml
+++ b/.github/workflows/make-sphinx-docs.yml
@@ -1,0 +1,27 @@
+name: "Make Sphinx Docs"
+on: 
+- workflow_dispatch
+- pull_request
+
+jobs:    
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: ammaraskar/sphinx-action@master
+      with:
+        docs-folder: "docs/"
+    # We need a .nojekyll file in the root of the gh-pages branch
+    # to prevent GitHub from ignoring files that begin with an underscore
+    # See: https://help.github.com/en/articles/files-that-start-with-an-underscore-are-missing
+    # Also: 
+    # - name: Add .nojekyll file
+    #   run: |
+    #     sudo touch docs/build/html/.nojekyll
+    - name: Deploy 🚀
+      uses: JamesIves/github-pages-deploy-action@v4
+      with:
+        branch: gh-pages # The branch the action should deploy to.
+        folder: docs/build/html
+        clean: true # Automatically remove deleted files from the deploy branch
+    

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -32,6 +32,7 @@
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.viewcode',
+    'sphinx.ext.githubpages',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -141,7 +142,7 @@ def setup(app):
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinx_rtd_theme'
+html_theme = 'classic'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
In case the current home of the documentation (on UCSB's server) were to ever disappear, in this PR, we add a Github Workflow that publishes the Sphinx documentation to the gh-pages branch of the repo.

If you then set Github Pages with these settings, the documentation is automatically published to the github pages site for the repo.

<img width="885" alt="image" src="https://github.com/rhelmot/sound-machine/assets/1119017/1417e385-bfeb-4b78-b783-20209a1066dd">

You can then automatically get a link by clicking the gear icon, upper right

<img width="371" alt="image" src="https://github.com/rhelmot/sound-machine/assets/1119017/6e2c63f5-a27c-4d89-8653-baf5a0755e0c">

And then clicking the checkbox for github pages:

<img width="387" alt="image" src="https://github.com/rhelmot/sound-machine/assets/1119017/a226a67e-7d5f-457c-b4ae-70507342ad68">

If you choose to merge this PR, you may then want to change the link in the README.md to point to the docs on Github Pages.
